### PR TITLE
Fix bug:Message: ReferenceError: can't access lexical declaration 'personData' before initialization

### DIFF
--- a/schockGag.js
+++ b/schockGag.js
@@ -14,6 +14,17 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-implicit-globals */
 
+class personDataDef {
+    shockGag = false
+    shockGagOwnerBlock = false
+    shockBells = false
+    shockBellsOwnerBlock = false
+    level = 0
+    process = 0
+}
+
+let personData = new personDataDef();
+
 async function waitFor(func, cancelFunc = () => false) {
     while (!func()) {
         if (cancelFunc()) {
@@ -30,7 +41,6 @@ function sleep(ms) {
 }
 async function start() {
     await waitFor(() => ServerSocket && ServerIsConnected && typeof Player.MemberNumber !== "undefined");
-    await sleep(2000)
     loadPersonList()
     ServerSocket.on('ChatRoomMessage', main);
     
@@ -38,16 +48,7 @@ async function start() {
 
 await start()
 
-class personDataDef {
-    shockGag = false
-    shockGagOwnerBlock = false
-    shockBells = false
-    shockBellsOwnerBlock = false
-    level = 0
-    process = 0
-}
 
-let personData = new personDataDef();
 
 function main(data){
     if ((data != null) &&

--- a/schockGag.js
+++ b/schockGag.js
@@ -31,8 +31,9 @@ function sleep(ms) {
 async function start() {
     await waitFor(() => ServerSocket && ServerIsConnected && typeof Player.MemberNumber !== "undefined");
     await sleep(2000)
-    ServerSocket.on('ChatRoomMessage', main);
     loadPersonList()
+    ServerSocket.on('ChatRoomMessage', main);
+    
 }
 
 await start()

--- a/schockGag.js
+++ b/schockGag.js
@@ -29,7 +29,7 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 async function start() {
-    await waitFor(() => ServerSocket && ServerIsConnected);
+    await waitFor(() => ServerSocket && ServerIsConnected && typeof Player.MemberNumber !== "undefined");
     ServerSocket.on('ChatRoomMessage', main);
     loadPersonList()
 }

--- a/schockGag.js
+++ b/schockGag.js
@@ -30,6 +30,7 @@ function sleep(ms) {
 }
 async function start() {
     await waitFor(() => ServerSocket && ServerIsConnected && typeof Player.MemberNumber !== "undefined");
+    await sleep(2000)
     ServerSocket.on('ChatRoomMessage', main);
     loadPersonList()
 }

--- a/schockGag.js
+++ b/schockGag.js
@@ -43,7 +43,6 @@ async function start() {
     await waitFor(() => ServerSocket && ServerIsConnected && typeof Player.MemberNumber !== "undefined");
     loadPersonList()
     ServerSocket.on('ChatRoomMessage', main);
-    
 }
 
 await start()


### PR DESCRIPTION
Fix the bug Message: ReferenceError: can't access lexical declaration 'personData' before initialization 
change of the order of the execution to initialize the variables first. 